### PR TITLE
fix/discernible-names-for-widget-and-header

### DIFF
--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -51,7 +51,7 @@
               </li>
             {{ else }}
               <li class="nav-item">
-                <a class="nav-link ps-0 py-1{{ if $active }} active{{ end }}" href="{{ .URL | relLangURL }}">{{ .Name }}</a>
+                <a class="nav-link ps-0 py-1{{ if $active }} active{{ end }}" href="{{ .URL | relLangURL }}" aria-label="{{ .Name }}">{{ .Name }}</a>
               </li>
             {{ end }}
           {{ end -}}
@@ -61,7 +61,7 @@
         <ul class="nav flex-column flex-md-row ms-md-auto me-md-n5 pe-md-2">
           {{ range .Site.Menus.social -}}
             <li class="nav-item">
-              <a class="nav-link ps-0 py-1" href="{{ .URL | relURL }}">{{ .Pre | safeHTML }}<small class="ms-2 d-md-none">{{ .Name | safeHTML }}</small></a>
+              <a class="nav-link ps-0 py-1" href="{{ .URL | relURL }}" aria-label="{{ .Name }}">{{ .Pre | safeHTML }}<small class="ms-2 d-md-none">{{ .Name | safeHTML }}</small></a>
             </li>
           {{ end -}}
         </ul>

--- a/static/js/widget.js
+++ b/static/js/widget.js
@@ -53,6 +53,7 @@ const bindWidgets = (() => {
             const webChatButton = document.createElement("button");
             webChatButton.id = "sui-webchat-btn";
             webChatButton.className = "widget-btn";
+            webChatButton.setAttribute("aria-label", "Open Webchat")
             
             const iframeContainer = document.createElement("iframe");
             iframeContainer.id = "sui-webchat";
@@ -90,6 +91,14 @@ const bindWidgets = (() => {
             widgetButton.href = url;
             widgetButton.rel = "noopener noreferrer";
             widgetButton.target = "_blank";
+
+            if (channel === channelTypes.whatsapp) {
+                widgetButton.setAttribute("aria-label", "Contact us on WhatsApp");
+            } else if (channel === channelTypes.facebook) {
+                widgetButton.setAttribute("aria-label", "Visit our Facebook page");
+            } else if (channel === channelTypes.line) {
+                widgetButton.setAttribute("aria-label", "Chat with us on LINE");
+            }
 
             widgetContainer.prepend(widgetButton);
         }


### PR DESCRIPTION
resolves: Links do not have a discernible name for widget links and header links.

![Screen Shot 2024-08-28 at 10 59 09 AM](https://github.com/user-attachments/assets/a3f3f7f0-7b3f-45d5-9ad1-6114b3ebac18)
