### PR TITLE
Fix product section redirects and navigation

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -9,7 +9,7 @@
 
 [[main]]
   name = "SeaX"
-  url = "/seax/seax-messaging/bulk-messaging-features/"
+  url = "/seax/"
   weight = 20
 
 [[main]]

--- a/content/en/seavoice/discord/1-intro-discord-bot.md
+++ b/content/en/seavoice/discord/1-intro-discord-bot.md
@@ -9,6 +9,7 @@ draft: false
 images: []
 aliases:
     - /seavoice/discord/discord_bot/
+    - /seavoice/
 toc: true
 url: /seavoice/discord/discord-bot/
 ---

--- a/content/en/seax/seax-omni/1-intro.md
+++ b/content/en/seax/seax-omni/1-intro.md
@@ -10,7 +10,8 @@ menu:
     parent: "seax-omni"
 aliases:
   - /seax/seax-messaging/seax-intro/
-url: /en/seax/seax-omni/seax-intro/
+  - /seax/
+url: /seax/seax-omni/seax-intro/
 weight: 1
 toc: true
 ---


### PR DESCRIPTION
- Add /seax/ redirect alias to SeaX intro page
- Add /seavoice/ redirect alias to SeaVoice Discord bot page
- Update SeaX header navigation to use /seax/ instead of direct bulk messaging link
- Ensure consistent redirect behavior across all product sections